### PR TITLE
Remove MacOS from binary list

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ node-canvas is a [Cairo](http://cairographics.org/)-backed Canvas implementation
 $ npm install canvas
 ```
 
-By default, binaries for macOS, Linux and Windows will be downloaded. If you want to build from source, use `npm install --build-from-source` and see the **Compiling** section below.
+By default, binaries Linux and Windows will be downloaded. If you want to build from source, use `npm install --build-from-source` and see the **Compiling** section below.
 
 The minimum version of Node.js required is **6.0.0**.
 


### PR DESCRIPTION
[Mac has been selling more M1 Macs than Intel Macs for almost 8months](https://www.macrumors.com/2021/04/21/apple-silicon-mac-sales-intel/) and that number is only accelerating. Given that binaries will not be downloaded for ARM Mac the readme should no longer claim otherwise.

Thanks for contributing!

